### PR TITLE
Add nix-index database

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,6 +157,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1707016097,
+        "narHash": "sha256-V4lHr6hFQ3rK650dh64Xffxsf4kse9vUYWsM+ldjkco=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "3e3dad2808379c522138e2e8b0eb73500721a237",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixos-flake": {
       "locked": {
         "lastModified": 1705036214,
@@ -262,6 +282,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
+        "nix-index-database": "nix-index-database",
         "nixos-flake": "nixos-flake",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
     systems.url = "github:nix-systems/default";
 
     # Software inputs
+    nix-index-database.url = "github:nix-community/nix-index-database";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
     nixvim.url = "github:nix-community/nixvim";
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/home.nix
+++ b/home.nix
@@ -1,6 +1,7 @@
 { flake, pkgs, ... }:
 {
   imports = [
+    flake.inputs.nix-index-database.hmModules.nix-index
     flake.inputs.nixvim.homeManagerModules.nixvim
   ];
 
@@ -76,6 +77,7 @@
       enable = true;
       enableZshIntegration = true;
     };
+    # nix-index-database.comma.enable = true;
 
     starship = {
       enable = true;


### PR DESCRIPTION
Use https://github.com/nix-community/nix-index-database to obviate having to manually run `nix-index` to generate the initial database.

There is also `comma` support (second command in the screenshot) which is left disabled in the PR.

<img width="508" alt="image" src="https://github.com/juspay/nix-dev-home/assets/3998/2d7361e5-55f1-40b2-b6e0-4268235d7cc9">
