### PR TITLE
Initialise files from project root in flake template

### DIFF
--- a/nix/template.nix
+++ b/nix/template.nix
@@ -4,7 +4,7 @@
   flake.templates.default = {
     description = "A `home-manager` template providing useful tools & settings for Nix-based development";
     path = builtins.path {
-      path = ./.;
+      path = inputs.self;
       filter = path: _: with inputs.nixpkgs.lib;
         !(hasSuffix "LICENSE" path ||
           hasSuffix "README.md" path ||


### PR DESCRIPTION
Here’s what is initialised now:
```sh
wrote: /Users/shivaraj/oss/tmp/toplevel.nix
wrote: /Users/shivaraj/oss/tmp/template.nix
```

This is after changing the path to `inputs.self`:
```sh
wrote: /Users/shivaraj/oss/tmp/.envrc
wrote: /Users/shivaraj/oss/tmp/config.nix
wrote: /Users/shivaraj/oss/tmp/nix/toplevel.nix
wrote: /Users/shivaraj/oss/tmp/nix/template.nix
wrote: /Users/shivaraj/oss/tmp/nix
wrote: /Users/shivaraj/oss/tmp/justfile
wrote: /Users/shivaraj/oss/tmp/home.nix
wrote: /Users/shivaraj/oss/tmp/.gitignore
wrote: /Users/shivaraj/oss/tmp/flake.nix
wrote: /Users/shivaraj/oss/tmp/.github/workflows/ci.yaml
wrote: /Users/shivaraj/oss/tmp/.github/workflows
wrote: /Users/shivaraj/oss/tmp/.github
```