### PR TITLE
neovim: enable live_grep and clipboard to unnamedplus

### DIFF
--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -17,6 +17,7 @@
       smartindent = true;
       tabstop = 2;
       number = true;
+      clipboard = "unnamedplus";
     };
 
     # Keymaps

--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -52,6 +52,10 @@
             desc = "file finder";
             action = "find_files";
           };
+          "<leader>fg" = {
+            desc = "find via grep";
+            action = "live_grep";
+          };
         };
         extensions = {
           file_browser.enable = true;


### PR DESCRIPTION
- Enabled live_grep option to search through the files via live_grep
- Set clipboard to unnamedplus to copy/paste outside of neovim