### PR TITLE
neovim: telescope fix

### DIFF
--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -47,13 +47,13 @@
       };
       telescope = {
         enable = true;
-        settings.keymaps = {
+        keymaps = {
           "<leader>ff" = {
-            desc = "file finder";
+            options.desc = "file finder";
             action = "find_files";
           };
           "<leader>fg" = {
-            desc = "find via grep";
+            options.desc = "find via grep";
             action = "live_grep";
           };
         };

--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -68,7 +68,7 @@
         servers = {
           hls.enable = true;
           marksman.enable = true;
-          nil_ls.enable = true;
+          nil-ls.enable = true;
           rust-analyzer = {
             enable = true;
             installCargo = false;


### PR DESCRIPTION
Currently telescope plugin is not working and file finder or find via grep options are not working. This PR resolves these issues.