### PR TITLE
chore(template): Ignore github workflows

### DIFF
--- a/nix/template.nix
+++ b/nix/template.nix
@@ -16,7 +16,7 @@
       filter = path: _: with inputs.nixpkgs.lib;
         !(hasSuffix "LICENSE" path ||
           hasSuffix "README.md" path ||
-          hasSuffix ".github/workflows/update-flake-lock.yaml" path);
+          hasSuffix ".github/" path);
     };
   };
 


### PR DESCRIPTION
Because we use self-hosted runners now.