### PR TITLE
direnv: Use the same nix package

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -121,6 +121,7 @@
     # https://nixos.asia/en/direnv
     direnv = {
       enable = true;
+      package = config.nix.package;
       nix-direnv.enable = true;
       config.global = {
         # Make direnv messages less verbose

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,4 +1,4 @@
-{ flake, pkgs, ... }:
+{ flake, config, pkgs, ... }:
 {
   imports = [
     ./nix-index.nix


### PR DESCRIPTION
In direnv, use the same Nix package as the user specifies here:

https://github.com/juspay/nix-dev-home/blob/d9df14e49eb7b291584dfb0a5df1323754bd7644/home/default.nix#L9-L12

context:

<img width="504" alt="image" src="https://github.com/user-attachments/assets/9245ee03-8b35-416b-bf28-fd5807125d91">
