### PR TITLE
Auto-merge flake.lock update PRs

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -27,4 +27,5 @@ jobs:
         if: steps.update.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr merge --auto --merge ${{ steps.update.outputs.pull-request-number }}
+          PR_NUMBER: ${{ steps.update.outputs.pull-request-number }}
+        run: gh pr merge --auto --merge "$PR_NUMBER"

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   example-lock:
     runs-on: ubuntu-latest
@@ -13,8 +17,14 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Update flake.lock
+        id: update
         uses: DeterminateSystems/update-flake-lock@main
         with:
           pr-title: "Update flake.lock"
           pr-labels: |
             automated
+      - name: Enable auto-merge
+        if: steps.update.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge --auto --merge ${{ steps.update.outputs.pull-request-number }}


### PR DESCRIPTION
**Weekly flake.lock update PRs now auto-merge once CI passes.** Previously, the `update-flake-lock` workflow created a PR but required manual merge, adding unnecessary toil for a routine dependency bump.

Added a `gh pr merge --auto --merge` step that fires after the PR is created, using the action's `pull-request-number` output. *Explicit `contents: write` and `pull-requests: write` permissions are declared on the workflow to ensure the token has the access it needs.*

> Requires "Allow auto-merge" to be enabled in the repository settings.