### PR TITLE
Add AGENTS.md and mcp-nixos config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "nixos": {
+      "command": "nix",
+      "args": ["run", "github:utensils/mcp-nixos"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+This is a Nix flake template for home-manager, NixOS, and nix-darwin configurations using [nixos-unified](https://nixos-unified.org/).
+
+## Key commands
+
+- `nix run` — activate the configuration
+- `nix flake check` — check the flake
+- `nix fmt` — format nix files
+
+## Structure
+
+- `flake.nix` — flake definition with autowiring via nixos-unified
+- `configurations/` — system and home-manager configurations
+- `modules/` — reusable NixOS/home-manager/nix-darwin modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,3 @@
 # AGENTS
 
-This is a Nix flake template for home-manager, NixOS, and nix-darwin configurations using [nixos-unified](https://nixos-unified.org/).
-
-## Key commands
-
-- `nix run` — activate the configuration
-- `nix flake check` — check the flake
-- `nix fmt` — format nix files
-
-## Structure
-
-- `flake.nix` — flake definition with autowiring via nixos-unified
-- `configurations/` — system and home-manager configurations
-- `modules/` — reusable NixOS/home-manager/nix-darwin modules
+After making configuration changes, run `nix run` to activate them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with minimal project context (key commands, structure)
- Symlink `CLAUDE.md` → `AGENTS.md` for Claude Code compatibility
- Add `.mcp.json` with [mcp-nixos](https://mcp-nixos.io/) server using `nix run` (no uvx/Python dependency)

All three files pass through the existing template filters in `template.nix`, so they'll be included in all template variants (home, nixos, nix-darwin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)