### PR TITLE
Update deprecated home-manager and NixOS options

### DIFF
--- a/modules/home/gc.nix
+++ b/modules/home/gc.nix
@@ -3,6 +3,6 @@
   nix.gc = {
     automatic = true;
     # Change how often the garbage collector runs (default: weekly)
-    # frequency = "monthly";
+    # dates = "monthly";
   };
 }

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -9,13 +9,11 @@
   programs = {
     git = {
       enable = true;
-      userName = config.me.fullname;
-      userEmail = config.me.email;
       ignores = [ "*~" "*.swp" ];
-      aliases = {
-        ci = "commit";
-      };
-      extraConfig = {
+      settings = {
+        user.name = config.me.fullname;
+        user.email = config.me.email;
+        alias.ci = "commit";
         # init.defaultBranch = "master";
         # pull.rebase = "false";
       };

--- a/modules/home/neovim/default.nix
+++ b/modules/home/neovim/default.nix
@@ -1,7 +1,7 @@
 { flake, ... }:
 {
   imports = [
-    flake.inputs.nixvim.homeManagerModules.nixvim
+    flake.inputs.nixvim.homeModules.nixvim
   ];
 
   programs.nixvim = import ./nixvim.nix // {

--- a/modules/home/nix-index.nix
+++ b/modules/home/nix-index.nix
@@ -3,7 +3,7 @@
   imports = [
     # NOTE: The nix-index DB is slow to search, until
     # https://github.com/nix-community/nix-index-database/issues/130
-    flake.inputs.nix-index-database.hmModules.nix-index
+    flake.inputs.nix-index-database.homeModules.nix-index
   ];
 
   # command-not-found handler to suggest nix way of installing stuff.

--- a/modules/nixos/gui/gnome.nix
+++ b/modules/nixos/gui/gnome.nix
@@ -1,9 +1,7 @@
 { pkgs, ... }:
 {
-  services.xserver = {
-    displayManager.gdm.enable = true;
-    desktopManager.gnome.enable = true;
-  };
+  services.displayManager.gdm.enable = true;
+  services.desktopManager.gnome.enable = true;
 
   environment.systemPackages = with pkgs; [
     pkgs.gnome-tweaks


### PR DESCRIPTION
## Summary

- Migrate `programs.git.{userName,userEmail,aliases,extraConfig}` to `programs.git.settings` 
- Fix commented option `frequency` → `dates` in `nix.gc`
- Update `services.xserver.{displayManager,desktopManager}` to `services.{displayManager,desktopManager}`
- Rename `nixvim.homeManagerModules` → `nixvim.homeModules`
- Rename `nix-index-database.hmModules` → `nix-index-database.homeModules`

Closes #228

## Test plan

- [x] `nix flake check` passes with no evaluation warnings from template code

🤖 Generated with [Claude Code](https://claude.com/claude-code)