### PR TITLE
Fix auto-merge for weekly flake.lock PRs

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -28,4 +28,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.update.outputs.pull-request-number }}
-        run: gh pr merge --auto --merge "$PR_NUMBER"
+        run: gh pr merge --auto --squash "$PR_NUMBER"


### PR DESCRIPTION
The weekly `update-flake-lock` workflow already has an *Enable auto-merge* step, but it never works — so PRs like #231 pile up waiting for a manual merge.

The cause: the step runs `gh pr merge --auto --merge`, but this repo has **merge commits disabled** (`allow_merge_commit: false` — only squash and rebase are allowed). GitHub rejects the request, the step fails, and auto-merge is never enabled.

Fix is one word: `--merge` → `--squash`. After this, each weekly PR gets auto-merge enabled and GitHub squash-merges it once the required `nix (...)` CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)